### PR TITLE
Add back local tests in separate workflow file

### DIFF
--- a/.github/workflows/local_tests.yml
+++ b/.github/workflows/local_tests.yml
@@ -1,0 +1,51 @@
+name: Local Tests
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - 'src/providers/local.ts'
+  pull_request:
+    branches: [ master ]
+    paths:
+      - 'src/providers/local.ts'
+
+jobs:
+
+  # These tests require a self-hosted runner.  If you are trying to make changes to the local storage
+  # provider and find these tests failing, please file an issue.
+
+  save-local-cache:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache npm
+        uses: ./
+        with:
+          type: npm
+          version: ${{ github.run_id }}
+          provider: local
+      - name: Install dependencies
+        run: |
+          npm ci
+          
+  restore-local-cache:
+    runs-on: self-hosted
+    needs: save-local-cache
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache npm
+        id: cache
+        uses: ./
+        with:
+          type: npm
+          version: ${{ github.run_id }}
+          provider: local
+      - name: Verify restore worked
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          echo "Restore failed!"
+          exit -1
+      - name: Install dependencies
+        run: |
+          npm ci

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -425,45 +425,6 @@ jobs:
           ${{ matrix.script }}
 
   # ======================================================================
-  # Local Storage Provider
-  # ======================================================================
-        
-  #save-local-cache:
-  #  runs-on: self-hosted
-  #  steps:
-  #    - uses: actions/checkout@v2
-  #    - name: Cache npm
-  #      uses: ./
-  #      with:
-  #        type: npm
-  #        version: ${{ github.run_id }}
-  #        provider: local
-  #    - name: Install dependencies
-  #      run: |
-  #        npm ci
-          
-  #restore-local-cache:
-  #  runs-on: self-hosted
-  #  needs: save-local-cache
-  #  steps:
-  #    - uses: actions/checkout@v2
-  #    - name: Cache npm
-  #      id: cache
-  #      uses: ./
-  #      with:
-  #        type: npm
-  #        version: ${{ github.run_id }}
-  #        provider: local
-  #    - name: Verify restore worked
-  #      if: steps.cache.outputs.cache-hit != 'true'
-  #      run: |
-  #        echo "Restore failed!"
-  #        exit -1
-  #    - name: Install dependencies
-  #      run: |
-  #        npm ci
-
-  # ======================================================================
   # S3 Storage Provider
   # ======================================================================
 


### PR DESCRIPTION
Using path filter to only run local storage tests, which require a self-hosted runner, when modifying the local storage provider.