### PR TITLE
Bump node to version 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ outputs:
   cache-restore-type:
     description: 'Indicates the restore type, either "miss", "partial", or "full"'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/restore/index.js'
   post: 'dist/save/index.js'
   post-if: 'success()'


### PR DESCRIPTION
Considering that github will no longer support node12, this bumps the action to use node16.